### PR TITLE
Create settings table - closes #38

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "preact": "^8.2.6",
     "preact-compat": "^3.17.0",
     "preact-router": "^2.5.7",
+    "unistore": "^3.2.1",
     "uuid": "^3.3.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "eslint-config-prettier": "^3.3.0",
-    "idb": "^2.1.3",
+    "idb": "^3.0.2",
     "preact": "^8.2.6",
     "preact-compat": "^3.17.0",
     "preact-router": "^2.5.7",

--- a/src/components/app.js
+++ b/src/components/app.js
@@ -16,6 +16,8 @@ import About from '../routes/about';
 import NotFound from '../routes/not-found';
 import { fudgeDates, ymd } from '../utils/date';
 import { getDefaultTheme } from '../utils/theme';
+import { connect } from 'unistore/preact';
+import { actions } from '../store/actions';
 
 const userTheme = localStorage.getItem('journalbook_theme');
 
@@ -42,13 +44,12 @@ const tables = [
 const isOnboarded = () => !!localStorage.getItem('journalbook_onboarded');
 const isMigrated = () => !!localStorage.getItem('journalbook_dates_migrated');
 
-export default class App extends Component {
+class App extends Component {
   state = {
     onboarded: isOnboarded(),
-    theme: getDefaultTheme(),
   };
 
-  componentDidMount() {
+  async componentDidMount() {
     if (userTheme === null) {
       window.matchMedia('(prefers-color-scheme: dark)').addListener(e => {
         const theme = e.matches ? 'dark' : '';
@@ -95,6 +96,8 @@ export default class App extends Component {
         });
       });
     }
+
+    await this.props.getSettings();
   }
 
   handleRoute = () => {
@@ -107,7 +110,9 @@ export default class App extends Component {
     }
   };
 
-  render({}, { onboarded, theme = '' }) {
+  render({ settings = {} }, { onboarded }) {
+    const theme = settings.theme || getDefaultTheme(settings);
+
     return (
       <div id="app" data-theme={theme}>
         <Header onboarded={onboarded} />
@@ -126,3 +131,8 @@ export default class App extends Component {
     );
   }
 }
+
+export default connect(
+  'settings',
+  actions
+)(App);

--- a/src/components/app.js
+++ b/src/components/app.js
@@ -16,43 +16,48 @@ import NotFound from '../routes/not-found';
 import { getDefaultTheme } from '../utils/theme';
 import { connect } from 'unistore/preact';
 import { actions } from '../store/actions';
+import { DBError } from './DBError';
 
 const userTheme = localStorage.getItem('journalbook_theme');
 const isOnboarded = () => !!localStorage.getItem('journalbook_onboarded');
-const isMigrated = () => !!localStorage.getItem('journalbook_dates_migrated');
 
 class App extends Component {
   state = {
     onboarded: isOnboarded(),
+    dbError: false,
   };
 
   async componentDidMount() {
-    if (userTheme === null) {
-      window.matchMedia('(prefers-color-scheme: dark)').addListener(e => {
-        const theme = e.matches ? 'dark' : '';
-        document.querySelector('#app').dataset.theme = theme;
-        this.setState({ theme });
-      });
-    }
-
-    const version = 4;
-    const dbPromise = openDb('entries-store', version, udb => {
-      switch (udb.oldVersion) {
-        case 0:
-          udb.createObjectStore('questions');
-        case 1:
-          udb.createObjectStore('entries');
-        case 2:
-          udb.createObjectStore('highlights');
-        case 3:
-          udb.createObjectStore('settings', {
-            theme: userTheme || '',
-          });
+    try {
+      if (userTheme === null) {
+        window.matchMedia('(prefers-color-scheme: dark)').addListener(e => {
+          const theme = e.matches ? 'dark' : '';
+          document.querySelector('#app').dataset.theme = theme;
+          this.setState({ theme });
+        });
       }
-    });
 
-    await dbPromise;
-    await this.props.boot(dbPromise);
+      const version = 4;
+      const dbPromise = openDb('entries-store', version, udb => {
+        switch (udb.oldVersion) {
+          case 0:
+            udb.createObjectStore('questions');
+          case 1:
+            udb.createObjectStore('entries');
+          case 2:
+            udb.createObjectStore('highlights');
+          case 3:
+            udb.createObjectStore('settings', {
+              theme: userTheme || '',
+            });
+        }
+      });
+
+      await dbPromise;
+      await this.props.boot(dbPromise);
+    } catch (e) {
+      this.setState({ dbError: true });
+    }
   }
 
   handleRoute = () => {
@@ -65,29 +70,40 @@ class App extends Component {
     }
   };
 
-  render({ settings = {} }, { onboarded }) {
+  render({ settings = {}, db }, { onboarded, dbError }) {
     const theme = settings.theme || getDefaultTheme(settings);
 
     return (
       <div id="app" data-theme={theme}>
         <Header onboarded={onboarded} />
-        <Router onChange={this.handleRoute}>
-          <Home path="/" />
-          <GetStarted path="/get-started/" />
-          <Settings path="/settings/" />
-          <About path="/about/" />
-          <Highlights path="/highlights/" />
-          <Day path="/:year/:month/:day" />
-          <Month path="/:year/:month" />
-          <Year path="/:year" />
-          <NotFound default />
-        </Router>
+        {db && (
+          <Router onChange={this.handleRoute}>
+            <Home path="/" />
+            <GetStarted path="/get-started/" />
+            <Settings path="/settings/" />
+            <About path="/about/" />
+            <Highlights path="/highlights/" />
+            <Day path="/:year/:month/:day" />
+            <Month path="/:year/:month" />
+            <Year path="/:year" />
+            <NotFound default />
+          </Router>
+        )}
+        {dbError && (
+          <DBError
+            toggle={() =>
+              this.setState({
+                dbError: false,
+              })
+            }
+          />
+        )}
       </div>
     );
   }
 }
 
 export default connect(
-  'settings',
+  'settings, db',
   actions
 )(App);

--- a/src/components/app.js
+++ b/src/components/app.js
@@ -1,9 +1,8 @@
 import { h, Component } from 'preact';
 import { Router } from 'preact-router';
-import idb from 'idb';
+import { openDb } from 'idb';
 import { sendBeacon } from '../utils/beacon';
 import Header from './Header';
-import { DB } from '../utils/db';
 
 import Home from '../routes/home';
 import Day from '../routes/day';
@@ -14,33 +13,11 @@ import GetStarted from '../routes/get-started';
 import Highlights from '../routes/highlights';
 import About from '../routes/about';
 import NotFound from '../routes/not-found';
-import { fudgeDates, ymd } from '../utils/date';
 import { getDefaultTheme } from '../utils/theme';
 import { connect } from 'unistore/preact';
 import { actions } from '../store/actions';
 
 const userTheme = localStorage.getItem('journalbook_theme');
-
-const tables = [
-  () => {},
-  db => {
-    db.createObjectStore('questions');
-  },
-  db => {
-    db.createObjectStore('entries');
-  },
-  db => {
-    db.createObjectStore('highlights');
-  },
-  db => {
-    db.createObjectStore('settings');
-    if (userTheme !== null) {
-      const database = new DB();
-      database.set('settings', 'theme', userTheme);
-    }
-  },
-];
-
 const isOnboarded = () => !!localStorage.getItem('journalbook_onboarded');
 const isMigrated = () => !!localStorage.getItem('journalbook_dates_migrated');
 
@@ -58,46 +35,24 @@ class App extends Component {
       });
     }
 
-    const version = tables.length - 1;
-    idb.open('entries-store', version, upgradeDB => {
-      for (let index = upgradeDB.oldVersion + 1; index <= version; index++) {
-        tables[index] && tables[index](upgradeDB);
+    const version = 4;
+    const dbPromise = openDb('entries-store', version, udb => {
+      switch (udb.oldVersion) {
+        case 0:
+          udb.createObjectStore('questions');
+        case 1:
+          udb.createObjectStore('entries');
+        case 2:
+          udb.createObjectStore('highlights');
+        case 3:
+          udb.createObjectStore('settings', {
+            theme: userTheme || '',
+          });
       }
     });
 
-    if (!isMigrated()) {
-      const db = new DB();
-      const table = 'entries';
-      // Get the existing keys
-      db.keys(table).then(keys => {
-        if (!keys.length) {
-          localStorage.setItem('journalbook_dates_migrated', true);
-          return;
-        }
-
-        Promise.all(
-          keys.map(key => {
-            // Get each item, parse the date and create a new key
-            return db.get(table, key).then(value => {
-              const oldKey = key.split('_');
-              const { year, month, day } = fudgeDates(oldKey[0]);
-              const newKey = ymd(new Date(year, month, day)) + '_' + oldKey[1];
-
-              // Set the new entry & delete the old entry
-              return db
-                .set(table, newKey, value)
-                .then(() => db.delete(table, key));
-            });
-          })
-        ).then(() => {
-          // Flag it up and reload
-          localStorage.setItem('journalbook_dates_migrated', true);
-          window.location.reload();
-        });
-      });
-    }
-
-    await this.props.getSettings();
+    await dbPromise;
+    await this.props.boot(dbPromise);
   }
 
   handleRoute = () => {

--- a/src/components/app.js
+++ b/src/components/app.js
@@ -17,6 +17,8 @@ import NotFound from '../routes/not-found';
 import { fudgeDates, ymd } from '../utils/date';
 import { getDefaultTheme } from '../utils/theme';
 
+const userTheme = localStorage.getItem('journalbook_theme');
+
 const tables = [
   () => {},
   db => {
@@ -27,6 +29,13 @@ const tables = [
   },
   db => {
     db.createObjectStore('highlights');
+  },
+  db => {
+    db.createObjectStore('settings');
+    if (userTheme !== null) {
+      const database = new DB();
+      database.set('settings', 'theme', userTheme);
+    }
   },
 ];
 
@@ -40,7 +49,7 @@ export default class App extends Component {
   };
 
   componentDidMount() {
-    if (localStorage.getItem('journalbook_theme') === null) {
+    if (userTheme === null) {
       window.matchMedia('(prefers-color-scheme: dark)').addListener(e => {
         const theme = e.matches ? 'dark' : '';
         document.querySelector('#app').dataset.theme = theme;

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,10 @@
 import './style';
 import App from './components/app';
+import { Provider } from 'unistore/preact';
+import store from './store';
 
-export default App;
+export default () => (
+  <Provider store={store}>
+    <App />
+  </Provider>
+);

--- a/src/routes/highlights/index.js
+++ b/src/routes/highlights/index.js
@@ -1,10 +1,10 @@
 import { h, Component } from 'preact';
-import { DB } from '../../utils/db';
 import Traverse from '../../components/Traverse';
 import { Link } from 'preact-router/match';
 import { parse, ymd, url, sortDates, shortDate } from '../../utils/date';
+import { connect } from 'unistore/preact';
 
-export default class Highlights extends Component {
+class Highlights extends Component {
   state = {
     years: {},
   };
@@ -14,8 +14,7 @@ export default class Highlights extends Component {
   }
 
   getData = async () => {
-    const db = new DB();
-    const highlights = await db.keys('highlights');
+    const highlights = await this.props.db.keys('highlights');
     const years = highlights.reduce((current, date) => {
       const year = date.substring(0, 4);
       if (!current[year]) current[year] = [];
@@ -67,3 +66,5 @@ export default class Highlights extends Component {
     );
   }
 }
+
+export default connect('db')(Highlights);

--- a/src/routes/months/index.js
+++ b/src/routes/months/index.js
@@ -5,11 +5,11 @@ import {
   pad,
   shortDate,
 } from '../../utils/date';
-import { DB } from '../../utils/db';
 import Traverse from '../../components/Traverse';
 import { Link } from 'preact-router/match';
+import { connect } from 'unistore/preact';
 
-export default class Month extends Component {
+class Month extends Component {
   state = {
     months: filledArray(),
   };
@@ -31,9 +31,8 @@ export default class Month extends Component {
       return;
     }
 
-    const db = new DB();
     const daysInMonth = new Date(year, month + 1, 0).getDate();
-    const dates = await db.keys('entries');
+    const dates = await this.props.db.keys('entries');
 
     const days = dates
       .map(x => x.split('_').shift())
@@ -102,3 +101,5 @@ export default class Month extends Component {
     );
   }
 }
+
+export default connect('db')(Month);

--- a/src/routes/settings/index.js
+++ b/src/routes/settings/index.js
@@ -191,7 +191,7 @@ class Settings extends Component {
     await this.props.db.clear('entries');
     await this.props.db.clear('questions');
     await this.props.db.clear('highlights');
-    await this.props.db.clear('settings');
+    await this.props.db.clear('highlights');
     localStorage.removeItem('journalbook_onboarded');
     window.location.href = '/';
   };
@@ -257,6 +257,7 @@ class Settings extends Component {
           <label for="theme">Theme</label>
           <select id="theme" onChange={this.updateTheme} value={theme}>
             <option value="">Default</option>
+            <option value="light">Light</option>
             <option value="dark">Dark</option>
           </select>
         </div>

--- a/src/routes/settings/index.js
+++ b/src/routes/settings/index.js
@@ -6,15 +6,16 @@ import { QuestionList } from '../../components/QuestionList';
 import { AddQuestion } from '../../components/AddQuestion';
 import { ScaryButton } from '../../components/ScaryButton';
 import { getDefaultTheme } from '../../utils/theme';
+import { actions } from '../../store/actions';
+import { connect } from 'unistore/preact';
 
-export default class Questions extends Component {
+class Settings extends Component {
   state = {
     db: null,
     questions: [],
     exporting: 0,
     importing: false,
     files: [],
-    theme: getDefaultTheme(),
   };
 
   async componentDidMount() {
@@ -26,9 +27,10 @@ export default class Questions extends Component {
 
   updateTheme = event => {
     const theme = event.target.value;
-    localStorage.setItem('journalbook_theme', theme);
-    document.querySelector('#app').dataset.theme = theme;
-    this.setState({ theme });
+    this.props.updateSetting({ key: 'theme', value: event.target.value });
+    // localStorage.setItem('journalbook_theme', theme);
+    // document.querySelector('#app').dataset.theme = theme;
+    // this.setState({ theme });
   };
 
   updateQuestion = (slug, value, attribute = 'text') => {
@@ -176,7 +178,9 @@ export default class Questions extends Component {
     window.location.href = '/';
   };
 
-  render(props, { questions, exporting, files, importing, theme = '' }) {
+  render({ settings = {} }, { questions, exporting, files, importing }) {
+    const theme = settings.theme || getDefaultTheme(settings);
+
     return (
       <div class="wrap lift-children">
         <QuestionList
@@ -242,3 +246,8 @@ export default class Questions extends Component {
     );
   }
 }
+
+export default connect(
+  'settings',
+  actions
+)(Settings);

--- a/src/routes/year/index.js
+++ b/src/routes/year/index.js
@@ -1,10 +1,10 @@
 import { h, Component } from 'preact';
 import { filledArray, months as monthNames, pad } from '../../utils/date';
-import { DB } from '../../utils/db';
 import Traverse from '../../components/Traverse';
 import { Link } from 'preact-router/match';
+import { connect } from 'unistore/preact';
 
-export default class Year extends Component {
+class Year extends Component {
   state = {
     months: filledArray(),
   };
@@ -25,8 +25,7 @@ export default class Year extends Component {
       return;
     }
 
-    const db = new DB();
-    const dates = await db.keys('entries');
+    const dates = await this.props.db.keys('entries');
 
     const months = dates
       .map(x => x.split('_').shift())
@@ -77,3 +76,5 @@ export default class Year extends Component {
     );
   }
 }
+
+export default connect('db')(Year);

--- a/src/store/actions.js
+++ b/src/store/actions.js
@@ -1,30 +1,26 @@
 import { DB } from '../utils/db';
-const db = new DB();
 
 export const actions = store => ({
-  updateSetting: (state, { key = '', value = '' }) => {
-    const settings = { ...state.settings };
-    settings[key] = value;
+  boot: async (state, dbPromise) => {
+    const db = new DB(dbPromise);
 
-    db.set('settings', key, value);
-
-    return {
-      settings,
-    };
-  },
-
-  getSettings: async state => {
     const settingKeys = await db.keys('settings');
     const savedSettings = await settingKeys.reduce(async (current, key) => {
       current[key] = await db.get('settings', key);
       return current;
     }, {});
 
-    return {
-      settings: {
-        ...state.settings,
-        ...savedSettings,
-      },
-    };
+    return { db, settings: { ...state.settings, ...savedSettings } };
+  },
+
+  updateSetting: (state, { key = '', value = '' }) => {
+    if (!state.db) return;
+
+    const settings = { ...state.settings };
+    settings[key] = value;
+
+    state.db.set('settings', key, value);
+
+    return { settings };
   },
 });

--- a/src/store/actions.js
+++ b/src/store/actions.js
@@ -1,0 +1,30 @@
+import { DB } from '../utils/db';
+const db = new DB();
+
+export const actions = store => ({
+  updateSetting: (state, { key = '', value = '' }) => {
+    const settings = { ...state.settings };
+    settings[key] = value;
+
+    db.set('settings', key, value);
+
+    return {
+      settings,
+    };
+  },
+
+  getSettings: async state => {
+    const settingKeys = await db.keys('settings');
+    const savedSettings = await settingKeys.reduce(async (current, key) => {
+      current[key] = await db.get('settings', key);
+      return current;
+    }, {});
+
+    return {
+      settings: {
+        ...state.settings,
+        ...savedSettings,
+      },
+    };
+  },
+});

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -1,0 +1,9 @@
+import createStore from 'unistore';
+
+const store = {
+  settings: {
+    theme: '',
+  },
+};
+
+export default createStore(store);

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -4,6 +4,7 @@ const store = {
   settings: {
     theme: '',
   },
+  db: null,
 };
 
 export default createStore(store);

--- a/src/utils/db.js
+++ b/src/utils/db.js
@@ -1,10 +1,10 @@
-import idb from 'idb';
+import { openDb } from 'idb';
 
 export class DB {
   db;
 
-  constructor(db) {
-    this.db = idb.open('entries-store');
+  constructor(dbPromise) {
+    this.db = dbPromise || openDb('entries-store');
   }
 
   get(table, key) {

--- a/src/utils/theme.js
+++ b/src/utils/theme.js
@@ -1,5 +1,5 @@
-export const getDefaultTheme = () => {
-  const theme = localStorage.getItem('journalbook_theme');
+export const getDefaultTheme = (settings = {}) => {
+  const theme = settings.theme || null;
 
   if (theme !== null) {
     return theme;


### PR DESCRIPTION
- [x] Create table
- [x] Migrate existing data
- [x] Read data from the DB on app launch, check fresh launches
- [x] Set sensible defaults
- [x] Read settings on `/settings`
- [x] Update settings
- [x] Potentially add unistore for global settings state
- [x] Upgrade to idb v3
- [x] Inject the DB around the app