### PR TITLE
Prefers reduced motion

### DIFF
--- a/src/store/actions.js
+++ b/src/store/actions.js
@@ -3,13 +3,7 @@ import { DB } from '../utils/db';
 export const actions = store => ({
   boot: async (state, dbPromise) => {
     const db = new DB(dbPromise);
-
-    const settingKeys = await db.keys('settings');
-    const savedSettings = await settingKeys.reduce(async (current, key) => {
-      current[key] = await db.get('settings', key);
-      return current;
-    }, {});
-
+    const savedSettings = await db.getObject('settings');
     return { db, settings: { ...state.settings, ...savedSettings } };
   },
 

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -3,6 +3,7 @@ import createStore from 'unistore';
 const store = {
   settings: {
     theme: '',
+    animation: '',
   },
   db: null,
 };

--- a/src/style/index.css
+++ b/src/style/index.css
@@ -171,6 +171,9 @@ hr {
   border-radius: 4px;
   margin: 0 0 20px;
   font-size: 12px;
+}
+
+[data-reduce-motion='false'] .button {
   transition: 300ms box-shadow;
 }
 
@@ -245,7 +248,7 @@ select {
 
 option {
   background: #eee;
-  color:#000;
+  color: #000;
 }
 
 [type='text'] {
@@ -340,9 +343,12 @@ textarea {
   width: calc(100% + 40px);
   margin: -40px -20px 10px;
   padding: 40px 20px 20px;
-  animation: lift 750ms forwards;
   background: var(--traverseBG);
   color: var(--traverse);
+}
+
+[data-reduce-motion='false'] .traverse {
+  animation: lift 750ms forwards;
 }
 
 .traverse--center {
@@ -357,7 +363,7 @@ textarea {
   margin-right: 0;
 }
 
-.traverse a {
+[data-reduce-motion='false'] .traverse a {
   transition: 300ms opacity;
 }
 
@@ -445,6 +451,9 @@ textarea {
   font: inherit;
   color: inherit;
   outline: none;
+}
+
+[data-reduce-motion='false'] .default-question {
   transition: 300ms box-shadow;
 }
 
@@ -470,8 +479,8 @@ textarea {
   }
 }
 
-.lift,
-.lift-children > * {
+[data-reduce-motion='false'] .lift,
+[data-reduce-motion='false'] .lift-children > * {
   animation: lift 750ms forwards;
   opacity: 0;
 }
@@ -525,7 +534,6 @@ textarea {
   border: 1px solid var(--line);
   position: absolute;
   border-radius: 1em;
-  transition: 300ms background-color;
   left: 0;
   top: 0;
 }
@@ -540,6 +548,13 @@ textarea {
   height: 100%;
   border: 1px solid var(--line);
   background: #fff;
+}
+
+[data-reduce-motion='false'] .toggle i {
+  transition: 300ms background-color;
+}
+
+[data-reduce-motion='false'] .toggle i:before {
   transition: 300ms transform;
 }
 
@@ -617,35 +632,6 @@ textarea {
   text-align: center;
 }
 
-/* Highlight */
-.highlight-today {
-  margin: 20px 20px;
-}
-
-.highlight-today svg {
-  vertical-align: middle;
-  margin: -2px 8px 0 0;
-}
-
-.highlight-today .button.clicked {
-  animation: shake 0.5s ease-in-out;
-}
-
-@keyframes shake {
-  33% {
-    transform: rotate(2deg);
-  }
-
-  66% {
-    transform: rotate(-2deg);
-  }
-
-  0%,
-  100% {
-    transform: rotate(0deg);
-  }
-}
-
 /* DB error */
 .db-error {
   position: fixed;
@@ -683,7 +669,6 @@ textarea {
   top: 0;
 }
 
-
 /* Themes */
 [data-theme='dark'] {
   --translucentLight: rgba(255, 255, 255, 0.1);
@@ -710,4 +695,3 @@ textarea {
 [data-theme='dark'] select {
   background-image: url('data:image/svg+xml;charset=utf-8;base64,PHN2ZyB3aWR0aD0iMTIiIGhlaWdodD0iOCIgdmlld0JveD0iMCAwIDEyIDgiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+PHBhdGggZD0iTS42NjggMS41MWw0Ljk3NCA0Ljk3NSA0Ljk0OC00Ljk1IiBzdHJva2U9InJnYmEoMjU1LDI1NSwyNTUsMC40KSIgc3Ryb2tlLXdpZHRoPSIyIiBmaWxsPSJub25lIiBmaWxsLXJ1bGU9ImV2ZW5vZGQiLz48L3N2Zz4=');
 }
-

--- a/src/utils/db.js
+++ b/src/utils/db.js
@@ -67,4 +67,14 @@ export class DB {
         .getAll()
     );
   }
+
+  async getObject(table) {
+    const keys = await this.keys(table);
+    const values = await Promise.all(keys.map(key => this.get(table, key)));
+
+    return values.reduce((current, entry, index) => {
+      current[keys[index]] = entry;
+      return current;
+    }, {});
+  }
 }

--- a/src/utils/theme.js
+++ b/src/utils/theme.js
@@ -11,3 +11,17 @@ export const getDefaultTheme = (settings = {}) => {
 
   return '';
 };
+
+export const prefersAnimation = (settings = {}) => {
+  const preference = settings.animation || null;
+
+  if (preference !== null) {
+    return preference;
+  }
+
+  if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
+    return 'off';
+  }
+
+  return '';
+};


### PR DESCRIPTION
Prefer not to have animations? That's no problem, they can now be turned off in the settings area. By default, they respect your browser choice for `prefers-reduced-motion`.

This is also a good test of the new settings table and database/store refactor. There's a new `db.getObject` method that'll resolve a table into full key/value pairs on an object.